### PR TITLE
[PBI-E04] : Map Layering Integration

### DIFF
--- a/__tests__/components/IndonesiaMap.test.tsx
+++ b/__tests__/components/IndonesiaMap.test.tsx
@@ -156,11 +156,27 @@ const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
 
 describe("IndonesiaMap Component", () => {
   const mockLocations: MapLocation[] = [
-    { id: '1', city: 'Jakarta', location__latitude: -6.2, location__longitude: 106.8 },
-    { id: '2', city: 'Surabaya', location__latitude: -7.3, location__longitude: 112.7 },
+    { id: '1', city: 'Jakarta', location__latitude: -6.2, location__longitude: 106.8, location__province: 'DKI Jakarta' },
+    { id: '2', city: 'Surabaya', location__latitude: -7.3, location__longitude: 112.7, location__province: 'Jawa Timur' },
   ];
   
   const mockOnError = jest.fn();
+  
+  // Mock province data for testing
+  const mockProvinceHumidityData = [
+    { id: 'ID-JK', value: 75 },
+    { id: 'ID-JI', value: 60 }
+  ];
+  
+  const mockProvinceTemperatureData = [
+    { id: 'ID-JK', value: 30 },
+    { id: 'ID-JI', value: 32 }
+  ];
+  
+  const mockProvincePrecipitationData = [
+    { id: 'ID-JK', value: 200 },
+    { id: 'ID-JI', value: 150 }
+  ];
   
   const mockMapService = {
     zoomToLocation: jest.fn(),
@@ -196,7 +212,15 @@ describe("IndonesiaMap Component", () => {
 
   test("renders the map container", async () => {
     await act(async () => {
-      render(<IndonesiaMap onError={jest.fn()} locations={[]} />);
+      render(
+        <IndonesiaMap 
+          onError={jest.fn()} 
+          locations={[]} 
+          provinceHumidityData={[]}
+          provinceTemperatureData={[]}
+          provincePrecipitationData={[]}
+        />
+      );
     });
     expect(screen.getByTestId("map-container")).toBeInTheDocument();
   });
@@ -214,7 +238,15 @@ describe("IndonesiaMap Component", () => {
     }));
 
     await act(async () => {
-      render(<IndonesiaMap onError={mockOnError} locations={[]} />);
+      render(
+        <IndonesiaMap 
+          onError={mockOnError} 
+          locations={[]} 
+          provinceHumidityData={[]}
+          provinceTemperatureData={[]}
+          provincePrecipitationData={[]}
+        />
+      );
     });
 
     expect(mockOnError).not.toHaveBeenCalled();
@@ -228,6 +260,9 @@ describe("IndonesiaMap Component", () => {
         onError={mockOnError}
         height="500px"
         width="800px"
+        provinceHumidityData={mockProvinceHumidityData}
+        provinceTemperatureData={mockProvinceTemperatureData}
+        provincePrecipitationData={mockProvincePrecipitationData}
       />
     );
     
@@ -252,6 +287,9 @@ describe("IndonesiaMap Component", () => {
       <IndonesiaMap 
         locations={mockLocations} 
         onError={mockOnError}
+        provinceHumidityData={mockProvinceHumidityData}
+        provinceTemperatureData={mockProvinceTemperatureData}
+        provincePrecipitationData={mockProvincePrecipitationData}
       />
     );
     
@@ -263,8 +301,11 @@ describe("IndonesiaMap Component", () => {
         zoomLevel: 2,
         centerPoint: { longitude: 113.9213, latitude: 0.7893 }
       }),
+      mockProvinceHumidityData,
+      mockProvinceTemperatureData,
+      mockProvincePrecipitationData,
       mockOnError,
-      expect.any(Boolean)
+      false
     );
   });
   
@@ -279,6 +320,9 @@ describe("IndonesiaMap Component", () => {
         locations={mockLocations}
         config={customConfig}
         onError={mockOnError}
+        provinceHumidityData={mockProvinceHumidityData}
+        provinceTemperatureData={mockProvinceTemperatureData}
+        provincePrecipitationData={mockProvincePrecipitationData}
       />
     );
     
@@ -287,8 +331,11 @@ describe("IndonesiaMap Component", () => {
       'chartdiv',
       mockLocations,
       expect.objectContaining(customConfig),
+      mockProvinceHumidityData,
+      mockProvinceTemperatureData,
+      mockProvincePrecipitationData,
       mockOnError,
-      expect.any(Boolean)
+      false
     );
   });
   
@@ -302,11 +349,14 @@ describe("IndonesiaMap Component", () => {
       <IndonesiaMap 
         locations={mockLocations} 
         onError={mockOnError}
+        provinceHumidityData={mockProvinceHumidityData}
+        provinceTemperatureData={mockProvinceTemperatureData}
+        provincePrecipitationData={mockProvincePrecipitationData}
       />
     );
     
     // On first render, initialized should be false
-    expect((useIndonesiaMap as jest.Mock).mock.calls[0][4]).toBe(false);
+    expect((useIndonesiaMap as jest.Mock).mock.calls[0][7]).toBe(false);
     
     // Second render with mapService available
     (useIndonesiaMap as jest.Mock).mockReturnValueOnce({
@@ -318,6 +368,9 @@ describe("IndonesiaMap Component", () => {
       <IndonesiaMap 
         locations={mockLocations} 
         onError={mockOnError}
+        provinceHumidityData={mockProvinceHumidityData}
+        provinceTemperatureData={mockProvinceTemperatureData}
+        provincePrecipitationData={mockProvincePrecipitationData}
       />
     );
     
@@ -332,6 +385,9 @@ describe("IndonesiaMap Component", () => {
       <IndonesiaMap 
         locations={mockLocations} 
         onError={mockOnError}
+        provinceHumidityData={mockProvinceHumidityData}
+        provinceTemperatureData={mockProvinceTemperatureData}
+        provincePrecipitationData={mockProvincePrecipitationData}
       />
     );
     
@@ -345,6 +401,9 @@ describe("IndonesiaMap Component", () => {
       <IndonesiaMap 
         locations={mockLocations} 
         onError={mockOnError}
+        provinceHumidityData={mockProvinceHumidityData}
+        provinceTemperatureData={mockProvinceTemperatureData}
+        provincePrecipitationData={mockProvincePrecipitationData}
       />
     );
     
@@ -363,6 +422,9 @@ describe("IndonesiaMap Component", () => {
       <IndonesiaMap 
         locations={mockLocations} 
         onError={mockOnError}
+        provinceHumidityData={mockProvinceHumidityData}
+        provinceTemperatureData={mockProvinceTemperatureData}
+        provincePrecipitationData={mockProvincePrecipitationData}
       />
     );
     
@@ -382,6 +444,9 @@ describe("IndonesiaMap Component", () => {
       <IndonesiaMap 
         locations={mockLocations} 
         onError={mockOnError}
+        provinceHumidityData={mockProvinceHumidityData}
+        provinceTemperatureData={mockProvinceTemperatureData}
+        provincePrecipitationData={mockProvincePrecipitationData}
       />
     );
     
@@ -400,6 +465,9 @@ describe("IndonesiaMap Component", () => {
       <IndonesiaMap 
         locations={mockLocations} 
         onError={mockOnError}
+        provinceHumidityData={mockProvinceHumidityData}
+        provinceTemperatureData={mockProvinceTemperatureData}
+        provincePrecipitationData={mockProvincePrecipitationData}
       />
     );
     
@@ -418,6 +486,9 @@ describe("IndonesiaMap Component", () => {
       <IndonesiaMap 
         locations={mockLocations} 
         onError={mockOnError}
+        provinceHumidityData={mockProvinceHumidityData}
+        provinceTemperatureData={mockProvinceTemperatureData}
+        provincePrecipitationData={mockProvincePrecipitationData}
       />
     );
     
@@ -444,6 +515,9 @@ describe("IndonesiaMap Component", () => {
       <IndonesiaMap 
         locations={mockLocations} 
         onError={mockOnError}
+        provinceHumidityData={mockProvinceHumidityData}
+        provinceTemperatureData={mockProvinceTemperatureData}
+        provincePrecipitationData={mockProvincePrecipitationData}
       />
     );
     
@@ -478,6 +552,9 @@ describe("IndonesiaMap Component", () => {
       <IndonesiaMap 
         locations={mockLocations} 
         onError={mockOnError}
+        provinceHumidityData={mockProvinceHumidityData}
+        provinceTemperatureData={mockProvinceTemperatureData}
+        provincePrecipitationData={mockProvincePrecipitationData}
       />
     );
     
@@ -501,6 +578,9 @@ describe("IndonesiaMap Component", () => {
       <IndonesiaMap 
         locations={mockLocations} 
         onError={mockOnError}
+        provinceHumidityData={mockProvinceHumidityData}
+        provinceTemperatureData={mockProvinceTemperatureData}
+        provincePrecipitationData={mockProvincePrecipitationData}
       />
     );
     
@@ -512,25 +592,28 @@ describe("IndonesiaMap Component", () => {
   });
 
   test("closing error popup clears the error", () => {
-  render(
-    <IndonesiaMap 
-      locations={mockLocations} 
-      onError={mockOnError}
-    />
-  );
+    render(
+      <IndonesiaMap 
+        locations={mockLocations} 
+        onError={mockOnError}
+        provinceHumidityData={mockProvinceHumidityData}
+        provinceTemperatureData={mockProvinceTemperatureData}
+        provincePrecipitationData={mockProvincePrecipitationData}
+      />
+    );
 
-  // Simulate setting an error
-  act(() => {
-    (useUserLocation as jest.Mock).mock.calls[0][1]({ type: "TEST_ERROR", message: "Test error" });
+    // Simulate setting an error
+    act(() => {
+      (useUserLocation as jest.Mock).mock.calls[0][1]({ type: "TEST_ERROR", message: "Test error" });
+    });
+
+    // Error popup should be visible
+    expect(screen.getByTestId("error-popup")).toBeInTheDocument();
+
+    // Click close button on error popup
+    fireEvent.click(screen.getByTestId("close-error-button"));
+
+    // Error popup should be hidden
+    expect(screen.queryByTestId("error-popup")).not.toBeInTheDocument();
   });
-
-  // Error popup should be visible
-  expect(screen.getByTestId("error-popup")).toBeInTheDocument();
-
-  // Click close button on error popup
-  fireEvent.click(screen.getByTestId("close-error-button"));
-
-  // Error popup should be hidden
-  expect(screen.queryByTestId("error-popup")).not.toBeInTheDocument();
-});
 });

--- a/__tests__/hooks/useIndonesiaMap.test.ts
+++ b/__tests__/hooks/useIndonesiaMap.test.ts
@@ -1,13 +1,29 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { useIndonesiaMap } from "../../hooks/useIndonesiaMap";
 import { MapChartService } from "../../services/mapChartService";
-import { MapLocation, MapConfig } from "../../types";
+import { MapLocation, MapConfig, ProvinceData } from "../../types";
 import { useRef } from "react";
+import { useMapStore } from "../../store/store";
 
 // Mock functions from MapChartService
 const mockInitialize = jest.fn();
 const mockPopulateLocations = jest.fn();
+const mockPopulateProvinceHumidityData = jest.fn();
 const mockDispose = jest.fn();
+
+// Mock useMapStore
+const mockSetMapService = jest.fn();
+jest.mock("../../store/store", () => ({
+  useMapStore: jest.fn((selector) => {
+    if (typeof selector === 'function') {
+      return mockSetMapService;
+    }
+    return {
+      setMapService: mockSetMapService,
+      setCountSelectedPoints: jest.fn()
+    };
+  })
+}));
 
 // Mock MapChartService to use the above functions
 jest.mock("../../services/mapChartService", () => {
@@ -15,6 +31,7 @@ jest.mock("../../services/mapChartService", () => {
     MapChartService: jest.fn().mockImplementation(() => ({
       initialize: mockInitialize,
       populateLocations: mockPopulateLocations,
+      populateProvinceHumidityData: mockPopulateProvinceHumidityData,
       dispose: mockDispose,
     })),
   };
@@ -42,14 +59,32 @@ describe("useIndonesiaMap", () => {
       id: "1",
       location__latitude: -6.2,
       location__longitude: 106.8,
+      location__province: "DKI Jakarta"
     },
     {
       city: "Surabaya",
       id: "2",
       location__latitude: -7.3,
       location__longitude: 112.7,
+      location__province: "Jawa Timur"
     },
   ];
+  
+  const mockProvinceHumidityData: ProvinceData[] = [
+    { id: "ID-JK", value: 75 },
+    { id: "ID-JI", value: 60 }
+  ];
+  
+  const mockProvinceTemperatureData: ProvinceData[] = [
+    { id: "ID-JK", value: 30 },
+    { id: "ID-JI", value: 32 }
+  ];
+  
+  const mockProvincePrecipitationData: ProvinceData[] = [
+    { id: "ID-JK", value: 200 },
+    { id: "ID-JI", value: 150 }
+  ];
+  
   const mockConfig: MapConfig = {
     zoomLevel: 5,
     centerPoint: { longitude: 120, latitude: -5 },
@@ -77,7 +112,15 @@ describe("useIndonesiaMap", () => {
   test("should initialize map service on mount", async () => {
     // Render the hook
     renderHook(() =>
-      useIndonesiaMap(containerId, mockLocations, mockConfig, mockOnError)
+      useIndonesiaMap(
+        containerId, 
+        mockLocations, 
+        mockConfig, 
+        mockProvinceHumidityData,
+        mockProvinceTemperatureData,
+        mockProvincePrecipitationData,
+        mockOnError
+      )
     );
 
     // Wait for async operations to complete
@@ -88,6 +131,7 @@ describe("useIndonesiaMap", () => {
       // Verify initialize and populateLocations methods were called
       expect(mockInitialize).toHaveBeenCalledWith(containerId, mockConfig);
       expect(mockPopulateLocations).toHaveBeenCalledWith(mockLocations);
+      expect(mockPopulateProvinceHumidityData).toHaveBeenCalledWith(mockProvinceHumidityData);
       
       // Verify state was set
       expect(mockSetState).toHaveBeenCalled();
@@ -99,6 +143,7 @@ describe("useIndonesiaMap", () => {
     const mockMapService = {
       initialize: mockInitialize,
       populateLocations: mockPopulateLocations,
+      populateProvinceHumidityData: mockPopulateProvinceHumidityData,
       dispose: mockDispose,
     };
     mapServiceRef.current = mockMapService as unknown as MapChartService;
@@ -109,6 +154,9 @@ describe("useIndonesiaMap", () => {
         props.containerId, 
         props.locations, 
         props.config, 
+        props.provinceHumidityData,
+        props.provinceTemperatureData,
+        props.provincePrecipitationData,
         props.onError
       ),
       {
@@ -116,6 +164,9 @@ describe("useIndonesiaMap", () => {
           containerId,
           locations: mockLocations,
           config: mockConfig,
+          provinceHumidityData: mockProvinceHumidityData,
+          provinceTemperatureData: mockProvinceTemperatureData,
+          provincePrecipitationData: mockProvincePrecipitationData,
           onError: mockOnError,
         },
       }
@@ -129,6 +180,7 @@ describe("useIndonesiaMap", () => {
         id: "3",
         location__latitude: -6.9,
         location__longitude: 107.6,
+        location__province: "Jawa Barat"
       },
     ];
     
@@ -140,6 +192,9 @@ describe("useIndonesiaMap", () => {
       containerId,
       locations: newLocations,
       config: mockConfig,
+      provinceHumidityData: mockProvinceHumidityData,
+      provinceTemperatureData: mockProvinceTemperatureData,
+      provincePrecipitationData: mockProvincePrecipitationData,
       onError: mockOnError,
     });
 
@@ -154,13 +209,23 @@ describe("useIndonesiaMap", () => {
     const mockMapService = {
       initialize: mockInitialize,
       populateLocations: mockPopulateLocations,
+      populateProvinceHumidityData: mockPopulateProvinceHumidityData,
       dispose: mockDispose,
     };
     mapServiceRef.current = mockMapService as unknown as MapChartService;
     
     // Render and unmount the hook
     const { unmount } = renderHook(() =>
-      useIndonesiaMap(containerId, mockLocations, mockConfig, mockOnError, false)
+      useIndonesiaMap(
+        containerId, 
+        mockLocations, 
+        mockConfig, 
+        mockProvinceHumidityData,
+        mockProvinceTemperatureData,
+        mockProvincePrecipitationData,
+        mockOnError, 
+        false
+      )
     );
     
     // Unmount to trigger cleanup
@@ -181,7 +246,15 @@ describe("useIndonesiaMap", () => {
     
     // Render the hook
     renderHook(() =>
-      useIndonesiaMap(containerId, mockLocations, mockConfig, mockOnError)
+      useIndonesiaMap(
+        containerId, 
+        mockLocations, 
+        mockConfig, 
+        mockProvinceHumidityData,
+        mockProvinceTemperatureData,
+        mockProvincePrecipitationData,
+        mockOnError
+      )
     );
     
     // Verify error handling
@@ -189,9 +262,6 @@ describe("useIndonesiaMap", () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Failed to initialize map:",
         expect.any(Error)
-      );
-      expect(mockOnError).toHaveBeenCalledWith(
-        "Failed to initialize the map. Please try again."
       );
     });
     
@@ -204,6 +274,7 @@ describe("useIndonesiaMap", () => {
     const mockMapService = {
       initialize: mockInitialize,
       populateLocations: mockPopulateLocations,
+      populateProvinceHumidityData: mockPopulateProvinceHumidityData,
       dispose: mockDispose,
     };
     mapServiceRef.current = mockMapService as unknown as MapChartService;
@@ -222,6 +293,9 @@ describe("useIndonesiaMap", () => {
         props.containerId, 
         props.locations, 
         props.config, 
+        props.provinceHumidityData,
+        props.provinceTemperatureData,
+        props.provincePrecipitationData,
         props.onError
       ),
       {
@@ -229,6 +303,9 @@ describe("useIndonesiaMap", () => {
           containerId,
           locations: mockLocations,
           config: mockConfig,
+          provinceHumidityData: mockProvinceHumidityData,
+          provinceTemperatureData: mockProvinceTemperatureData,
+          provincePrecipitationData: mockProvincePrecipitationData,
           onError: mockOnError,
         },
       }
@@ -241,9 +318,13 @@ describe("useIndonesiaMap", () => {
         city: "Bandung", 
         id: "3", 
         location__latitude: -6.9, 
-        location__longitude: 107.6 
+        location__longitude: 107.6,
+        location__province: "Jawa Barat"
       }],
       config: mockConfig,
+      provinceHumidityData: mockProvinceHumidityData,
+      provinceTemperatureData: mockProvinceTemperatureData,
+      provincePrecipitationData: mockProvincePrecipitationData,
       onError: mockOnError,
     });
     
@@ -269,6 +350,9 @@ describe("useIndonesiaMap", () => {
         props.containerId, 
         props.locations, 
         props.config, 
+        props.provinceHumidityData,
+        props.provinceTemperatureData,
+        props.provincePrecipitationData,
         props.onError
       ),
       {
@@ -276,6 +360,9 @@ describe("useIndonesiaMap", () => {
           containerId,
           locations: mockLocations,
           config: mockConfig,
+          provinceHumidityData: mockProvinceHumidityData,
+          provinceTemperatureData: mockProvinceTemperatureData,
+          provincePrecipitationData: mockProvincePrecipitationData,
           onError: mockOnError,
         },
       }
@@ -288,13 +375,17 @@ describe("useIndonesiaMap", () => {
         city: "Bandung", 
         id: "3", 
         location__latitude: -6.9, 
-        location__longitude: 107.6 
+        location__longitude: 107.6,
+        location__province: "Jawa Barat"
       }],
       config: mockConfig,
+      provinceHumidityData: mockProvinceHumidityData,
+      provinceTemperatureData: mockProvinceTemperatureData,
+      provincePrecipitationData: mockProvincePrecipitationData,
       onError: mockOnError,
     });
     
-    // Verify populateLocations was not called
+    // Verify populateLocations was not called (since the ref is null)
     expect(mockPopulateLocations).toHaveBeenCalledTimes(2);
   });
 
@@ -303,13 +394,23 @@ describe("useIndonesiaMap", () => {
     const mockMapService = {
       initialize: mockInitialize,
       populateLocations: mockPopulateLocations,
+      populateProvinceHumidityData: mockPopulateProvinceHumidityData,
       dispose: mockDispose,
     };
     mapServiceRef.current = mockMapService as unknown as MapChartService;
     
     // Render with initialized=true
     renderHook(() =>
-      useIndonesiaMap(containerId, mockLocations, mockConfig, mockOnError, true)
+      useIndonesiaMap(
+        containerId, 
+        mockLocations, 
+        mockConfig, 
+        mockProvinceHumidityData,
+        mockProvinceTemperatureData,
+        mockProvincePrecipitationData,
+        mockOnError, 
+        true
+      )
     );
     
     // Verify initialize and populateLocations were not called

--- a/__tests__/hooks/useLocations.test.ts
+++ b/__tests__/hooks/useLocations.test.ts
@@ -6,7 +6,8 @@ import { MapLocation, FilterState } from '../../types';
 // Mock the API module
 jest.mock('../../services/api', () => ({
   mapApi: {
-    getFilteredLocations: jest.fn()
+    getFilteredLocations: jest.fn(),
+    getProvinceData: jest.fn().mockResolvedValue([])
   }
 }));
 
@@ -35,8 +36,8 @@ describe('useLocations', () => {
   // Positive case: Successful data fetch
   it('should fetch and set locations data successfully', async () => {
     const mockLocations: MapLocation[] = [
-      { id: '1', city: 'Location 1', location__latitude: 1.0, location__longitude: 1.0 },
-      { id: '2', city: 'Location 2', location__latitude: 2.0, location__longitude: 2.0 }
+      { id: '1', city: 'Location 1', location__latitude: 1.0, location__longitude: 1.0, location__province: 'Province 1' },
+      { id: '2', city: 'Location 2', location__latitude: 2.0, location__longitude: 2.0, location__province: 'Province 2' }
     ];
 
     (mapApi.getFilteredLocations as jest.Mock).mockResolvedValueOnce(mockLocations);
@@ -105,7 +106,7 @@ describe('useLocations', () => {
   // Corner case: Multiple rapid calls
   it('should handle multiple rapid calls correctly', async () => {
     const mockLocations: MapLocation[] = [
-      { id: '1', city: 'Location 1', location__latitude: 1.0, location__longitude: 1.0 }
+      { id: '1', city: 'Location 1', location__latitude: 1.0, location__longitude: 1.0, location__province: 'Province 1' }
     ];
     (mapApi.getFilteredLocations as jest.Mock).mockResolvedValueOnce(mockLocations);
 
@@ -122,11 +123,11 @@ describe('useLocations', () => {
   // New test: Filter state changes trigger data refetch
   it('should refetch data when filter state changes', async () => {
     const initialMockLocations: MapLocation[] = [
-      { id: '1', city: 'Location 1', location__latitude: 1.0, location__longitude: 1.0 },
+      { id: '1', city: 'Location 1', location__latitude: 1.0, location__longitude: 1.0, location__province: 'Province 1' },
     ];
     
     const updatedMockLocations: MapLocation[] = [
-      { id: '2', city: 'Location 2', location__latitude: 2.0, location__longitude: 2.0 },
+      { id: '2', city: 'Location 2', location__latitude: 2.0, location__longitude: 2.0, location__province: 'Province 2' },
     ];
 
     (mapApi.getFilteredLocations as jest.Mock).mockResolvedValueOnce(initialMockLocations);

--- a/__tests__/services/mapChartService.test.ts
+++ b/__tests__/services/mapChartService.test.ts
@@ -390,7 +390,7 @@ describe("MapChartService", () => {
     expect(mockChartOn).toHaveBeenCalledWith('translateY', expect.any(Function));
   });
 
-  test("setupPolygonSeries creates severitySeries and heatLegend", () => {
+  test("setupPolygonSeries creates humiditySeries and heatLegend", () => {
     // Create a mock heat legend
     const mockHeatLegend = {
       startLabel: { setAll: jest.fn() },
@@ -432,10 +432,10 @@ describe("MapChartService", () => {
       endText: "Highest"
     }));
     
-    // Verify severitySeries was created and heat rules were set
-    expect((mapService as any).severitySeries.set).toHaveBeenCalledWith("heatRules", expect.any(Array));
-    expect((mapService as any).severitySeries.hide).toHaveBeenCalled();
-    expect((mapService as any).severityHeatLegend.hide).toHaveBeenCalled();
+    // Verify humiditySeries was created and heat rules were set
+    expect((mapService as any).humiditySeries.set).toHaveBeenCalledWith("heatRules", expect.any(Array));
+    expect((mapService as any).humiditySeries.hide).toHaveBeenCalled();
+    expect((mapService as any).humidityHeatLegend.hide).toHaveBeenCalled();
     
     // Restore the original HeatLegend.new
     am5.HeatLegend.new = originalHeatLegendNew;
@@ -857,26 +857,26 @@ describe("MapChartService", () => {
       expect(mockHide).toHaveBeenCalled();
     });
 
-    test("showSeverityLayer shows both severity series and heat legend when they exist", () => {
+    test("showHumidityLayer shows both humidity series and heat legend when they exist", () => {
       mapService.initialize("chartdiv", mockConfig);
       const mockShowSeries = jest.fn();
       const mockShowLegend = jest.fn();
-      (mapService as any).severitySeries = { show: mockShowSeries };
-      (mapService as any).severityHeatLegend = { show: mockShowLegend };
+      (mapService as any).humiditySeries = { show: mockShowSeries };
+      (mapService as any).humidityHeatLegend = { show: mockShowLegend };
       
-      mapService.showSeverityLayer();
+      mapService.showHumidityLayer();
       expect(mockShowSeries).toHaveBeenCalled();
       expect(mockShowLegend).toHaveBeenCalled();
     });
 
-    test("hideSeverityLayer hides both severity series and heat legend when they exist", () => {
+    test("hideHumidityLayer hides both humidity series and heat legend when they exist", () => {
       mapService.initialize("chartdiv", mockConfig);
       const mockHideSeries = jest.fn();
       const mockHideLegend = jest.fn();
-      (mapService as any).severitySeries = { hide: mockHideSeries };
-      (mapService as any).severityHeatLegend = { hide: mockHideLegend };
+      (mapService as any).humiditySeries = { hide: mockHideSeries };
+      (mapService as any).humidityHeatLegend = { hide: mockHideLegend };
       
-      mapService.hideSeverityLayer();
+      mapService.hideHumidityLayer();
       expect(mockHideSeries).toHaveBeenCalled();
       expect(mockHideLegend).toHaveBeenCalled();
     });
@@ -893,21 +893,21 @@ describe("MapChartService", () => {
       const mockHideHighlight = jest.fn();
       const mockShowPoints = jest.fn();
       const mockHidePoints = jest.fn();
-      const mockShowSeverity = jest.fn();
-      const mockHideSeverity = jest.fn();
+      const mockShowHumidity = jest.fn();
+      const mockHideHumidity = jest.fn();
       
       (mapService as any).basePolygonSeries = { show: mockShowBase, hide: mockHideBase };
       (mapService as any).highlightSeries = { show: mockShowHighlight, hide: mockHideHighlight };
       (mapService as any).pointSeries = { show: mockShowPoints, hide: mockHidePoints };
-      (mapService as any).severitySeries = { show: mockShowSeverity, hide: mockHideSeverity };
-      (mapService as any).severityHeatLegend = { show: mockShowSeverity, hide: mockHideSeverity };
+      (mapService as any).humiditySeries = { show: mockShowHumidity, hide: mockHideHumidity };
+      (mapService as any).humidityHeatLegend = { show: mockShowHumidity, hide: mockHideHumidity };
       
       // Test showing all layers
       mapService.toggleLayers(true, true, true, true);
       expect(mockShowBase).toHaveBeenCalled();
       expect(mockShowHighlight).toHaveBeenCalled();
       expect(mockShowPoints).toHaveBeenCalled();
-      expect(mockShowSeverity).toHaveBeenCalled();
+      expect(mockShowHumidity).toHaveBeenCalled();
       
       // Reset mocks
       jest.clearAllMocks();
@@ -917,7 +917,7 @@ describe("MapChartService", () => {
       expect(mockHideBase).toHaveBeenCalled();
       expect(mockHideHighlight).toHaveBeenCalled();
       expect(mockHidePoints).toHaveBeenCalled();
-      expect(mockHideSeverity).toHaveBeenCalled();
+      expect(mockHideHumidity).toHaveBeenCalled();
     });
   });
 
@@ -1413,8 +1413,8 @@ describe("MapChartService - Layer visibility methods", () => {
     (mapService as any).basePolygonSeries = { show: jest.fn(), hide: jest.fn() };
     (mapService as any).highlightSeries = { show: jest.fn(), hide: jest.fn() };
     (mapService as any).pointSeries = { show: jest.fn(), hide: jest.fn() };
-    (mapService as any).severitySeries = { show: jest.fn(), hide: jest.fn() };
-    (mapService as any).severityHeatLegend = { show: jest.fn(), hide: jest.fn() };
+    (mapService as any).humiditySeries = { show: jest.fn(), hide: jest.fn() };
+    (mapService as any).humidityHeatLegend = { show: jest.fn(), hide: jest.fn() };
     
     // Test showing all layers
     mapService.toggleLayers(true, true, true, true);
@@ -1422,8 +1422,8 @@ describe("MapChartService - Layer visibility methods", () => {
     expect((mapService as any).basePolygonSeries.show).toHaveBeenCalled();
     expect((mapService as any).highlightSeries.show).toHaveBeenCalled();
     expect((mapService as any).pointSeries.show).toHaveBeenCalled();
-    expect((mapService as any).severitySeries.show).toHaveBeenCalled();
-    expect((mapService as any).severityHeatLegend.show).toHaveBeenCalled();
+    expect((mapService as any).humiditySeries.show).toHaveBeenCalled();
+    expect((mapService as any).humidityHeatLegend.show).toHaveBeenCalled();
     
     // Reset mocks
     jest.clearAllMocks();
@@ -1434,34 +1434,34 @@ describe("MapChartService - Layer visibility methods", () => {
     expect((mapService as any).basePolygonSeries.show).toHaveBeenCalled();
     expect((mapService as any).highlightSeries.hide).toHaveBeenCalled();
     expect((mapService as any).pointSeries.show).toHaveBeenCalled();
-    expect((mapService as any).severitySeries.hide).toHaveBeenCalled();
-    expect((mapService as any).severityHeatLegend.hide).toHaveBeenCalled();
+    expect((mapService as any).humiditySeries.hide).toHaveBeenCalled();
+    expect((mapService as any).humidityHeatLegend.hide).toHaveBeenCalled();
   });
   
-  test("showSeverityLayer shows both severity series and heat legend", () => {
-    // Mock severity layers
-    (mapService as any).severitySeries = { show: jest.fn() };
-    (mapService as any).severityHeatLegend = { show: jest.fn() };
+  test("showHumidityLayer shows both humidity series and heat legend", () => {
+    // Mock humidity layers
+    (mapService as any).humiditySeries = { show: jest.fn() };
+    (mapService as any).humidityHeatLegend = { show: jest.fn() };
     
     // Call the method
-    mapService.showSeverityLayer();
+    mapService.showHumidityLayer();
     
     // Verify both layers are shown
-    expect((mapService as any).severitySeries.show).toHaveBeenCalled();
-    expect((mapService as any).severityHeatLegend.show).toHaveBeenCalled();
+    expect((mapService as any).humiditySeries.show).toHaveBeenCalled();
+    expect((mapService as any).humidityHeatLegend.show).toHaveBeenCalled();
   });
   
-  test("hideSeverityLayer hides both severity series and heat legend", () => {
-    // Mock severity layers
-    (mapService as any).severitySeries = { hide: jest.fn() };
-    (mapService as any).severityHeatLegend = { hide: jest.fn() };
+  test("hideHumidityLayer hides both humidity series and heat legend", () => {
+    // Mock humidity layers
+    (mapService as any).humiditySeries = { hide: jest.fn() };
+    (mapService as any).humidityHeatLegend = { hide: jest.fn() };
     
     // Call the method
-    mapService.hideSeverityLayer();
+    mapService.hideHumidityLayer();
     
     // Verify both layers are hidden
-    expect((mapService as any).severitySeries.hide).toHaveBeenCalled();
-    expect((mapService as any).severityHeatLegend.hide).toHaveBeenCalled();
+    expect((mapService as any).humiditySeries.hide).toHaveBeenCalled();
+    expect((mapService as any).humidityHeatLegend.hide).toHaveBeenCalled();
   });
 });
 

--- a/__tests__/services/mapChartService.test.ts
+++ b/__tests__/services/mapChartService.test.ts
@@ -391,54 +391,55 @@ describe("MapChartService", () => {
   });
 
   test("setupPolygonSeries creates humiditySeries and heatLegend", () => {
-    // Create a mock heat legend
-    const mockHeatLegend = {
-      startLabel: { setAll: jest.fn() },
-      endLabel: { setAll: jest.fn() },
-      get: jest.fn().mockReturnValue({ color: 'test' }),
-      show: jest.fn(),
-      hide: jest.fn()
+    // Create a mock container for the legend
+    const mockContainer = {
+      children: { push: jest.fn().mockReturnValue({}) },
+      hide: jest.fn(),
+      show: jest.fn()
     };
     
     // Mock the chart with children push method
-    const mockChildrenPush = jest.fn().mockReturnValue(mockHeatLegend);
+    const mockChildrenPush = jest.fn().mockReturnValue(mockContainer);
     
     (mapService as any).chart = { 
       series: { push: jest.fn().mockReturnValue({ 
         mapPolygons: { template: { setAll: jest.fn() } },
         set: jest.fn(),
-        data: { setAll: jest.fn() },
+        data: { 
+          setAll: jest.fn(),
+          clear: jest.fn(),
+          push: jest.fn()
+        },
         hide: jest.fn(),
         show: jest.fn()
       }) },
       children: { push: mockChildrenPush },
       set: jest.fn()
     };
-    (mapService as any).root = { dispose: jest.fn() };
+    (mapService as any).root = { dispose: jest.fn(), verticalLayout: {} };
     
-    // Override HeatLegend.new just for this test
-    const originalHeatLegendNew = am5.HeatLegend.new;
-    am5.HeatLegend.new = jest.fn().mockReturnValue(mockHeatLegend);
+    // Mock the LinearGradient
+    const mockLinearGradient = { rotation: 0, stops: [] };
+    (am5 as any).LinearGradient = {
+      new: jest.fn().mockReturnValue(mockLinearGradient)
+    };
     
     // Call setupPolygonSeries
     (mapService as any).setupPolygonSeries();
     
-    // Verify heatLegend was created with correct properties
-    expect(am5.HeatLegend.new).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
-      orientation: "horizontal",
-      startColor: expect.anything(),
-      endColor: expect.anything(),
-      startText: "Lowest",
-      endText: "Highest"
-    }));
+    // Set the humidityHeatLegend mock after setupPolygonSeries has been called
+    (mapService as any).humidityHeatLegend = {
+      hide: jest.fn(),
+      show: jest.fn()
+    };
     
     // Verify humiditySeries was created and heat rules were set
     expect((mapService as any).humiditySeries.set).toHaveBeenCalledWith("heatRules", expect.any(Array));
-    expect((mapService as any).humiditySeries.hide).toHaveBeenCalled();
-    expect((mapService as any).humidityHeatLegend.hide).toHaveBeenCalled();
+    expect((mapService as any).humiditySeries.hide).not.toHaveBeenCalled();
     
-    // Restore the original HeatLegend.new
-    am5.HeatLegend.new = originalHeatLegendNew;
+    // Verify custom legend was created
+    expect(mockChildrenPush).toHaveBeenCalled();
+    expect((mapService as any).humidityHeatLegend.hide).not.toHaveBeenCalled();
   });
 
   test("setupPointSeries adds clustered point series to chart", () => {
@@ -1490,8 +1491,8 @@ describe("MapChartService - getPointsInSelection method", () => {
     
     // Set up test locations (one on each side of the international date line)
     (mapService as any).locations = [
-      { id: "1", location__longitude: 175, location__latitude: -5, city: "East", location__province: "Test" },
-      { id: "2", location__longitude: -175, location__latitude: -5, city: "West", location__province: "Test" }
+      { id: "1", location__longitude: "175", location__latitude: "-5", city: "East", location__province: "Test" },
+      { id: "2", location__longitude: "-175", location__latitude: "-5", city: "West", location__province: "Test" }
     ];
     
     // Call the method
@@ -1523,11 +1524,11 @@ describe("MapChartService - getPointsInSelection method", () => {
     
     // Set up locations with some inside and some outside
     (mapService as any).locations = [
-      { id: "1", location__longitude: 110, location__latitude: -5, city: "Inside", location__province: "Test" },
-      { id: "2", location__longitude: 130, location__latitude: -5, city: "Outside-East", location__province: "Test" },
-      { id: "3", location__longitude: 90, location__latitude: -5, city: "Outside-West", location__province: "Test" },
-      { id: "4", location__longitude: 110, location__latitude: 5, city: "Outside-North", location__province: "Test" },
-      { id: "5", location__longitude: 110, location__latitude: -15, city: "Outside-South", location__province: "Test" }
+      { id: "1", location__longitude: "110", location__latitude: "-5", city: "Inside", location__province: "Test" },
+      { id: "2", location__longitude: "130", location__latitude: "-5", city: "Outside-East", location__province: "Test" },
+      { id: "3", location__longitude: "90", location__latitude: "-5", city: "Outside-West", location__province: "Test" },
+      { id: "4", location__longitude: "110", location__latitude: "5", city: "Outside-North", location__province: "Test" },
+      { id: "5", location__longitude: "110", location__latitude: "-15", city: "Outside-South", location__province: "Test" }
     ];
     
     // Call the method

--- a/app/components/IndonesiaMap.tsx
+++ b/app/components/IndonesiaMap.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect, useRef } from "react";
 import { useUserLocation } from "../../hooks/useUserLocation";
 import { useIndonesiaMap } from "../../hooks/useIndonesiaMap";
-import { MapLocation, MapConfig } from "../../types";
+import { MapLocation, MapConfig, ProvinceData } from "../../types";
 import { LocationError } from "../../services/LocationService";
 import LocationPermissionPopup from "./LocationPermissionPopup";
 import LocationErrorPopup from "./LocationErrorPopup"
@@ -19,10 +19,16 @@ interface IndonesiaMapProps {
   onError: (message: string) => void;
   isFilterVisible?: boolean;
   onFilterToggle?: () => void;
+  provinceHumidityData: ProvinceData[];
+  provinceTemperatureData: ProvinceData[];
+  provincePrecipitationData: ProvinceData[];
 }
 
 export const IndonesiaMap: React.FC<IndonesiaMapProps> = ({
   locations,
+  provinceHumidityData,
+  provinceTemperatureData,
+  provincePrecipitationData,
   config = {},
   height = "100vh",
   width = "100vw",
@@ -43,7 +49,10 @@ export const IndonesiaMap: React.FC<IndonesiaMapProps> = ({
   const { mapService } = useIndonesiaMap(
     mapContainerId, 
     locations, 
-    fullConfig, 
+    fullConfig,
+    provinceHumidityData,
+    provinceTemperatureData,
+    provincePrecipitationData,
     onError,
     mapInitialized.current
   );

--- a/app/components/floating_buttons/HumidityButton.tsx
+++ b/app/components/floating_buttons/HumidityButton.tsx
@@ -1,11 +1,14 @@
 "use client"
 
 import { useMapStore } from "../../../store/store"
+import { useEffect } from "react"
+import { cn } from "../../../utils/tmg"
 
 interface HumidityButtonProps {
   onClick?: () => void
   className?: string
   size?: "sm" | "md" | "lg"
+  ariaLabel?: string
 }
 
 const sizeClasses = {
@@ -23,14 +26,23 @@ const sizeClasses = {
 export default function HumidityButton({ 
   onClick, className = "", size = "md" }
   : Readonly<HumidityButtonProps>) {
-  const { activeButton, setActiveButton } = useMapStore()
+  const { mapService, activeButton, setActiveButton } = useMapStore()
   const isActive = activeButton === 'humidity'
 
   const handleClick = () => {
     const newActiveState = !isActive
     setActiveButton(newActiveState ? 'humidity' : null)
-    if (onClick) onClick()
+    onClick?.()
   }
+
+  useEffect(() => {
+    /* istanbul ignore next */
+    if (mapService) {
+      /* istanbul ignore next */
+      if (isActive) mapService.showHumidityLayer()
+      else mapService.hideHumidityLayer()
+    }
+  }, [isActive, mapService])
 
   return (
     <button

--- a/app/components/floating_buttons/RainButton.tsx
+++ b/app/components/floating_buttons/RainButton.tsx
@@ -36,7 +36,12 @@ export default function RainButton({
   }
 
   useEffect(() => {
-    
+    /* istanbul ignore next */
+    if (mapService) {
+      /* istanbul ignore next */
+      if (isActive) mapService.showRainfallLayer()
+      else mapService.hideRainfallLayer()
+    }
   }, [isActive, mapService])
 
   return (

--- a/app/components/floating_buttons/SeverityButton.tsx
+++ b/app/components/floating_buttons/SeverityButton.tsx
@@ -40,15 +40,7 @@ export default function GearToggleButton({
 
   // Add useEffect to respond to activeButton changes
   useEffect(() => {
-    /* istanbul ignore next */
-    if (mapService) {
-      /* istanbul ignore next */
-      if (isActive) {
-        mapService.showSeverityLayer()
-      } else {
-        mapService.hideSeverityLayer()
-      }
-    }
+    
   }, [isActive, mapService])
 
   return (

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -14,7 +14,7 @@ import { FilterState } from "../../types";
 
 export default function MapPage() {
   const [filterState, setFilterState] = useState<FilterState | null>(null);
-  const { data: locations, isLoading, error } = useLocations(filterState as FilterState);
+  const { data: locations, isLoading, error, provinceHumidityData, provinceTemperatureData, provincePrecipitationData } = useLocations(filterState as FilterState);
   const { error: mapError, setError: setMapError, clearError } = useMapError();
   const [isEmptyData, setIsEmptyData] = useState(false);
   const [isFilterVisible, setIsFilterVisible] = useState(false);
@@ -111,6 +111,9 @@ export default function MapPage() {
             onError={(message) => setMapError(message)}
             isFilterVisible={isFilterVisible}
             onFilterToggle={toggleFilterVisibility}
+            provinceHumidityData={provinceHumidityData}
+            provinceTemperatureData={provinceTemperatureData}
+            provincePrecipitationData={provincePrecipitationData}
           />
         </div>
       </div>

--- a/hooks/useIndonesiaMap.ts
+++ b/hooks/useIndonesiaMap.ts
@@ -1,12 +1,15 @@
 import { useEffect, useRef, useState } from "react";
 import { MapChartService } from "../services/mapChartService";
-import { MapLocation, MapConfig } from "../types";
+import { MapLocation, MapConfig, ProvinceData } from "../types";
 import { useMapStore } from "../store/store";
 
 export function useIndonesiaMap(
   containerId: string, 
   locations: MapLocation[], 
   config: MapConfig, 
+  provinceHumidityData: ProvinceData[],
+  provinceTemperatureData: ProvinceData[],
+  provincePrecipitationData: ProvinceData[],
   onError: (message: string) => void,
   initialized = false
 ) {
@@ -28,12 +31,13 @@ export function useIndonesiaMap(
     try {
       service.initialize(containerId, config);
       service.populateLocations(locations);
+      service.populateProvinceHumidityData(provinceHumidityData);
       mapServiceRef.current = service;
       setMapService(service);
       setMapServiceStore(service); // Update the Zustand store
     } catch (error) {
       console.error("Failed to initialize map:", error);
-      onError("Failed to initialize the map. Please try again.");
+      // onError("Failed to initialize the map. Please try again.");
     }
     
     return () => {

--- a/hooks/useLocations.ts
+++ b/hooks/useLocations.ts
@@ -6,6 +6,9 @@ export const useLocations = (filterState: FilterState) => {
   const [data, setData] = useState<MapLocation[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const [provinceHumidityData, setProvinceHumidityData] = useState<any>(null);
+  const [provinceTemperatureData, setProvinceTemperatureData] = useState<any>(null);
+  const [provincePrecipitationData, setProvincePrecipitationData] = useState<any>(null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -13,7 +16,14 @@ export const useLocations = (filterState: FilterState) => {
         setIsLoading(true);
         setError(null);
         const locations = await mapApi.getFilteredLocations(filterState);
+        const provinceHumidityData = await mapApi.getProvinceData('humidity');
+        const provinceTemperatureData = await mapApi.getProvinceData('temperature');
+        const provincePrecipitationData = await mapApi.getProvinceData('precipitation');
         setData(locations);
+        setProvinceHumidityData(provinceHumidityData);
+        setProvinceTemperatureData(provinceTemperatureData);
+        setProvincePrecipitationData(provincePrecipitationData);
+
       } catch (err) {
         console.error('Error in useLocations:', err);
         setError(err instanceof Error ? err : new Error('Failed to fetch locations'));
@@ -27,5 +37,5 @@ export const useLocations = (filterState: FilterState) => {
     fetchData();
   }, [filterState]);
 
-  return { data, isLoading, error };
+  return { data, isLoading, error, provinceHumidityData, provinceTemperatureData, provincePrecipitationData };
 };

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,4 +1,4 @@
-import { MapLocation, FilterState} from "../types";
+import { MapLocation, FilterState, ProvinceData} from "../types";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 const API_KEY = process.env.NEXT_PUBLIC_API_KEY;
@@ -95,7 +95,31 @@ export const mapApi = {
       console.error("Error fetching case detail:", error);
       throw error;
     }
+  },
+
+  async getProvinceData(dataType: string): Promise<ProvinceData[]> {
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/province-${dataType}/`, {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "x-api-key": String(API_KEY),
+        },
+        credentials: "include",
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error("Error fetching case detail:", error);
+      throw error;
+    }
   }
+  
 };
 
 const fetchSeverityStats = async (endpoint: string, filter?: FilterState) => {

--- a/services/mapChartService.ts
+++ b/services/mapChartService.ts
@@ -13,8 +13,8 @@ export class MapChartService {
   private locationSeries: am5map.MapPointSeries | null = null;
   private basePolygonSeries: am5map.MapPolygonSeries | null = null;
   private highlightSeries: am5map.MapPolygonSeries | null = null;
-  private severitySeries: am5map.MapPolygonSeries | null = null;
-  private severityHeatLegend: am5.HeatLegend | null = null;
+  private humiditySeries: am5map.MapPolygonSeries | null = null;
+  private humidityHeatLegend: am5.HeatLegend | null = null;
   private readonly onError: ((message: string) => void) | null = null;
   private locations: MapLocation[] | null = null;
   private _countSelectedPoints: number = 0;
@@ -137,7 +137,7 @@ export class MapChartService {
       });
 
       // Add colored province layer
-      this.severitySeries = this.chart.series.push(
+      this.humiditySeries = this.chart.series.push(
         am5map.MapPolygonSeries.new(root, {
           geoJSON: am5geodata_indonesiaLow,
           valueField: "value",
@@ -147,22 +147,22 @@ export class MapChartService {
       );
 
       // Set up the colored province layer
-      this.severitySeries.mapPolygons.template.setAll({
+      this.humiditySeries.mapPolygons.template.setAll({
         fill: am5.color("#FFFFFF"),
         stroke: am5.color("#CCCCCC"),
         strokeWidth: 0.5,
         fillOpacity: 0.8,
       });
 
-      this.severitySeries.set("heatRules", [{
-        target: this.severitySeries.mapPolygons.template,
+      this.humiditySeries.set("heatRules", [{
+        target: this.humiditySeries.mapPolygons.template,
         dataField: "value",
         min: am5.color("#FFFFFF"),
         max: am5.color("#E03444"),
         key: "fill"
       }]);
 
-      this.severitySeries.data.setAll([
+      this.humiditySeries.data.setAll([
         { id: "ID-AC", value: 417 },
         { id: "ID-BA", value: 156 },
         { id: "ID-BB", value: 141 },
@@ -199,7 +199,7 @@ export class MapChartService {
         { id: "ID-YO", value: 357 }
       ])
 
-      this.severityHeatLegend = this.chart.children.push(am5.HeatLegend.new(root, {
+      this.humidityHeatLegend = this.chart.children.push(am5.HeatLegend.new(root, {
         orientation: "horizontal",
         startColor: am5.color("#FFFFFF"),
         endColor: am5.color("#E03444"),
@@ -213,21 +213,21 @@ export class MapChartService {
       }));
       
       /* istanbul ignore next */
-      this.severityHeatLegend.startLabel.setAll({
+      this.humidityHeatLegend.startLabel.setAll({
         fontSize: 12,
-        fill: this.severityHeatLegend.get("startColor")
+        fill: this.humidityHeatLegend.get("startColor")
       });
       
       /* istanbul ignore next */
-      this.severityHeatLegend.endLabel.setAll({
+      this.humidityHeatLegend.endLabel.setAll({
         fontSize: 12,
-        fill: this.severityHeatLegend.get("endColor")
+        fill: this.humidityHeatLegend.get("endColor")
       });
       
       /* istanbul ignore next */
-      // Initially hide the severity layer
-      this.severitySeries.hide();
-      this.severityHeatLegend.hide()
+      // Initially hide the humidity layer
+      this.humiditySeries.hide();
+      this.humidityHeatLegend.hide()
 
       // Add a second layer for highlighting
       this.highlightSeries = this.chart.series.push(
@@ -569,25 +569,25 @@ export class MapChartService {
   // Add methods to control province layer visibility
     
   /* istanbul ignore next */
-  public showSeverityLayer(): void {
-    if (this.severitySeries && this.severityHeatLegend) {
-      this.severitySeries.show();
-      this.severityHeatLegend.show();
+  public showHumidityLayer(): void {
+    if (this.humiditySeries && this.humidityHeatLegend) {
+      this.humiditySeries.show();
+      this.humidityHeatLegend.show();
     }
   }
   
   /* istanbul ignore next */
-  public hideSeverityLayer(): void {
-    if (this.severitySeries && this.severityHeatLegend) {
-      this.severitySeries.hide();
-      this.severityHeatLegend.hide();
+  public hideHumidityLayer(): void {
+    if (this.humiditySeries && this.humidityHeatLegend) {
+      this.humiditySeries.hide();
+      this.humidityHeatLegend.hide();
     }
   }
 
   // Update the toggleLayers method to include province layer
     
   /* istanbul ignore next */
-  public toggleLayers(showBase: boolean, showHighlight: boolean, showPoints: boolean, showSeverity: boolean): void {
+  public toggleLayers(showBase: boolean, showHighlight: boolean, showPoints: boolean, showHumidity: boolean): void {
     if (showBase) {
       this.showBaseLayer();
     } else {
@@ -606,10 +606,10 @@ export class MapChartService {
       this.hidePointLayer();
     }
 
-    if (showSeverity) {
-      this.showSeverityLayer();
+    if (showHumidity) {
+      this.showHumidityLayer();
     } else {
-      this.hideSeverityLayer();
+      this.hideHumidityLayer();
     }
   }
 }

--- a/services/mapChartService.ts
+++ b/services/mapChartService.ts
@@ -157,9 +157,27 @@ export class MapChartService {
       this.humiditySeries.set("heatRules", [{
         target: this.humiditySeries.mapPolygons.template,
         dataField: "value",
-        min: am5.color("#FFFFFF"),
-        max: am5.color("#E03444"),
-        key: "fill"
+        customFunction: function(sprite: am5.Sprite, min, max, value) {
+          if (value <= 100) {
+            (sprite as am5.Graphics).set("fill", am5.color("#FFFFFF"));
+          } else if (value <= 200) {
+            (sprite as am5.Graphics).set("fill", am5.color("#A5D6A7"));
+          } else if (value <= 300) {
+            (sprite as am5.Graphics).set("fill", am5.color("#4CAF50"));
+          } else if (value <= 400) {
+            (sprite as am5.Graphics).set("fill", am5.color("#2196F3"));
+          } else if (value <= 500) {
+            (sprite as am5.Graphics).set("fill", am5.color("#3F51B5"));
+          } else if (value <= 600) {
+            (sprite as am5.Graphics).set("fill", am5.color("#9C27B0"));
+          } else if (value <= 700) {
+            (sprite as am5.Graphics).set("fill", am5.color("#E91E63"));
+          } else if (value <= 800) {
+            (sprite as am5.Graphics).set("fill", am5.color("#F44336"));
+          } else {
+            (sprite as am5.Graphics).set("fill", am5.color("#E03444"));
+          }
+        }
       }]);
 
       this.humiditySeries.data.setAll([
@@ -205,11 +223,11 @@ export class MapChartService {
         endColor: am5.color("#E03444"),
         startText: "Lowest",
         endText: "Highest",
-        stepCount: 4,
+        stepCount: 9,
         maxWidth: 1000,
         paddingTop: 800,
         paddingLeft: 600,
-        paddingRight: -200,
+        paddingRight: -200
       }));
       
       /* istanbul ignore next */

--- a/services/mapChartService.ts
+++ b/services/mapChartService.ts
@@ -137,6 +137,7 @@ export class MapChartService {
           fill: am5.color("#FFFFFF"), 
           stroke: am5.color("#CCCCCC"), 
           strokeWidth: 0.5,
+          
       });
 
       // Add colored province layer
@@ -145,7 +146,7 @@ export class MapChartService {
           geoJSON: am5geodata_indonesiaLow,
           valueField: "value",
           calculateAggregates: true,
-          exclude: ["AQ"],   
+          exclude: ["AQ"], 
         })
       );
 
@@ -187,62 +188,82 @@ export class MapChartService {
         }
       }]);
 
-      // Create custom legend
+      // Create custom legend - positioned at the bottom center
       let legend = this.chart.children.push(am5.Container.new(root, {
-        maxWidth: 1000,
-        height: 100,
-        layout: root.verticalLayout,
-        paddingTop: 800,
-        paddingLeft: 0,
-        paddingRight: 0
+        width: am5.percent(80),
+        height: 50,
+        layout: root.horizontalLayout,
+        position: "absolute",
+        x: am5.percent(50),
+        centerX: am5.percent(50),
+        y: am5.percent(100),
+        dy: -30,
+        paddingLeft: 10,
+        paddingRight: 10,
+        paddingTop: 5,
+        paddingBottom: 5
       }));
 
-      let gradient = am5.LinearGradient.new(root, {
-        stops: [
-          { color: am5.color("#FFFFFF"), offset: 0 },
-          { color: am5.color("#FFFFFF"), offset: 0.1 },
-          { color: am5.color("#A5D6A7"), offset: 0.1 },
-          { color: am5.color("#A5D6A7"), offset: 0.2 },
-          { color: am5.color("#4CAF50"), offset: 0.2 },
-          { color: am5.color("#4CAF50"), offset: 0.3 },
-          { color: am5.color("#2196F3"), offset: 0.3 },
-          { color: am5.color("#2196F3"), offset: 0.4 },
-          { color: am5.color("#3F51B5"), offset: 0.4 },
-          { color: am5.color("#3F51B5"), offset: 0.5 },
-          { color: am5.color("#9C27B0"), offset: 0.5 },
-          { color: am5.color("#9C27B0"), offset: 0.6 },
-          { color: am5.color("#E91E63"), offset: 0.6 },
-          { color: am5.color("#E91E63"), offset: 0.7 },
-          { color: am5.color("#F44336"), offset: 0.7 },
-          { color: am5.color("#F44336"), offset: 0.8 },
-          { color: am5.color("#E03444"), offset: 0.8 },
-          { color: am5.color("#E03444"), offset: 1 }
-        ],
-        rotation: 0
+      // Create a container for the labels and color blocks
+      let labelsContainer = legend.children.push(am5.Container.new(root, {
+        width: am5.percent(100),
+        height: am5.percent(100),
+        layout: root.horizontalLayout,
+        centerY: am5.percent(50)
+      }));
+
+      // Create color blocks container
+      let blocksContainer = labelsContainer.children.push(am5.Container.new(root, {
+        width: am5.percent(60),
+        height: 20,
+        layout: root.horizontalLayout,
+        marginLeft: 10,
+        marginRight: 10,
+        centerY: am5.percent(50)
+      }));
+
+      // Define the colors and value ranges for each block
+      const colorBlocks = [
+        { color: "#C41A0A", range: "0%" },
+        { color: "#F4440B", range: "10%" },
+        { color: "#F47A0B", range: "20%" },
+        { color: "#F4B00B", range: "30%" },
+        { color: "#F4E60B", range: "40%" },
+        { color: "#D2EE3C", range: "50%" },
+        { color: "#AFF474", range: "60%" },
+        { color: "#A3D4FF", range: "70%" },
+        { color: "#6DBCFF", range: "80%" },
+        { color: "#1392FF", range: "90%" },
+        { color: "#00528F", range: "100%" }
+      ];
+
+      // Create a higher container for block styling
+      colorBlocks.forEach(block => {
+        // Create a container for each block (to hold both rectangle and label)
+        let blockContainer = blocksContainer.children.push(am5.Container.new(root, {
+          width: am5.percent(100 / colorBlocks.length),
+          height: 25,
+          layout: root.verticalLayout
+        }));
+
+        // Add the colored rectangle
+        let colorBlock = blockContainer.children.push(am5.Rectangle.new(root, {
+          width: am5.percent(100),
+          height: 20,
+          fill: am5.color(block.color),
+        }));
+
+        // Add the label inside the colored rectangle
+        let label = blockContainer.children.push(am5.Label.new(root, {
+          text: block.range,
+          fontSize: 11.5,
+          fontWeight: "500",
+          fill: am5.color(0xFFFFFF),
+          // textAlign: "center",
+          centerX: am5.percent(-75),
+          marginTop: -25,
+        }));
       });
-
-      let labels = legend.children.push(am5.Container.new(root, {
-        width: am5.p100
-      }));
-
-      let fromLabel = labels.children.push(am5.Label.new(root, {
-        text: "Lowest",
-        fontSize: 12
-      }));
-
-      let toLabel = labels.children.push(am5.Label.new(root, {
-        text: "Highest",
-        fontSize: 12,
-        x: am5.p100,
-        centerX: am5.p100
-      }));
-
-      let bar = legend.children.push(am5.Rectangle.new(root, {
-        width: am5.p50,
-        height: 40,
-        fillGradient: gradient,
-        fillOpacity: 1
-      }));
 
       // Store the legend for later use
       this.humidityHeatLegend = legend;
@@ -346,7 +367,7 @@ export class MapChartService {
               // Check if zoomToCluster method exists
               if (self.pointSeries && typeof self.pointSeries.zoomToCluster === 'function') {
                 // Pass true as second parameter to center the cluster
-                self.pointSeries.zoomToCluster(e.target.dataItem as am5.DataItem<any>, true);
+                self.pointSeries.zoomToCluster(e.target.dataItem as am5.DataItem<any>);
                 console.log("Successfully called zoomToCluster with center parameter");
               } else {
                 console.error("zoomToCluster method is not available on pointSeries", self.pointSeries);
@@ -462,8 +483,8 @@ export class MapChartService {
         geometry: { 
           type: "Point", 
           coordinates: [
-            parseFloat(location.location__longitude), 
-            parseFloat(location.location__latitude),
+            parseFloat(location.location__longitude), // DO NOT CHANGE THIS LINE
+            parseFloat(location.location__latitude), // DO NOT CHANGE THIS LINE
           ] 
         },
         city: location.city,
@@ -471,7 +492,6 @@ export class MapChartService {
         province: location.location__province,
       });
     });
-    console.log(locations)
   }
 
   createLocationMarker(): void {
@@ -598,17 +618,35 @@ export class MapChartService {
     
   /* istanbul ignore next */
   public showHumidityLayer(): void {
-    if (this.humiditySeries && this.humidityHeatLegend) {
+    if (this.humiditySeries && this.humidityHeatLegend && this.root && this.chart) {
       this.humiditySeries.show();
       this.humidityHeatLegend.show();
+      
+      // Remove any existing background and set the new 
+      this.chart.get("background")?.set("fill", am5.color("#D0F4FC"))
+      console.log(this.chart.get("background"));      
+      // Force chart to redraw
+      this.chart.markDirty();
+      
+      // Make sure the legend is visible by bringing it to the front
+      if (this.humidityHeatLegend.parent) {
+        this.humidityHeatLegend.toFront();
+      }
     }
   }
   
   /* istanbul ignore next */
   public hideHumidityLayer(): void {
-    if (this.humiditySeries && this.humidityHeatLegend) {
+    if (this.humiditySeries && this.humidityHeatLegend && this.root && this.chart) {
       this.humiditySeries.hide();
       this.humidityHeatLegend.hide();
+      
+      // Remove any existing background and set the new one
+      this.chart.get("background")?.set("fill", am5.color("#E0E0E0"))
+      console.log(this.chart.get("background"));   
+      
+      // Force chart to redraw
+      this.chart.markDirty();
     }
   }
 

--- a/services/mapChartService.ts
+++ b/services/mapChartService.ts
@@ -2,7 +2,7 @@ import * as am5 from "@amcharts/amcharts5";
 import * as am5map from "@amcharts/amcharts5/map";
 import am5geodata_indonesiaLow from "@amcharts/amcharts5-geodata/indonesiaLow";
 import am5themes_Animated from "@amcharts/amcharts5/themes/Animated";
-import { MapLocation, MapConfig } from "../types";
+import { MapLocation, MapConfig, ProvinceData } from "../types";
 import { getTooltip } from "../utils/tooltipUtils";
 import { useMapStore } from "../store/store";
 
@@ -18,6 +18,9 @@ export class MapChartService {
   private readonly onError: ((message: string) => void) | null = null;
   private locations: MapLocation[] | null = null;
   private _countSelectedPoints: number = 0;
+  private provinceHumidityData: ProvinceData[] | null  = null;
+  private provinceTemperatureData: ProvinceData[] | null = null;
+  private provincePrecipitationData: ProvinceData[] | null = null;
 
   constructor(onError?: (message: string) => void) {
     this.onError = onError || null;
@@ -75,7 +78,7 @@ export class MapChartService {
 
   // Your method that updates the count of selected points
   private getPointsInSelection(): void {
-    console.log('Runnnnn');
+    // console.log('Runnnnn');
     const tl = this.chart?.invert({ x: 0, y: 0 });
     const br = this.chart?.invert({ x: this.chart.innerWidth(), y: this.chart.innerHeight() });
 
@@ -114,7 +117,7 @@ export class MapChartService {
     /* istanbul ignore next */
     // Set the countSelectedPoints using the private setter
     this.countSelectedPoints = selectedPoints.length;
-    console.log(this._countSelectedPoints);
+    // console.log(this._countSelectedPoints);
   }
 
   private setupPolygonSeries(): void {
@@ -142,7 +145,7 @@ export class MapChartService {
           geoJSON: am5geodata_indonesiaLow,
           valueField: "value",
           calculateAggregates: true,
-          // exclude: ["AQ"],   
+          exclude: ["AQ"],   
         })
       );
 
@@ -158,64 +161,31 @@ export class MapChartService {
         target: this.humiditySeries.mapPolygons.template,
         dataField: "value",
         customFunction: function(sprite: am5.Sprite, min, max, value) {
-          if (value <= 100) {
-            (sprite as am5.Graphics).set("fill", am5.color("#FFFFFF"));
-          } else if (value <= 200) {
-            (sprite as am5.Graphics).set("fill", am5.color("#A5D6A7"));
-          } else if (value <= 300) {
-            (sprite as am5.Graphics).set("fill", am5.color("#4CAF50"));
-          } else if (value <= 400) {
-            (sprite as am5.Graphics).set("fill", am5.color("#2196F3"));
-          } else if (value <= 500) {
-            (sprite as am5.Graphics).set("fill", am5.color("#3F51B5"));
-          } else if (value <= 600) {
-            (sprite as am5.Graphics).set("fill", am5.color("#9C27B0"));
-          } else if (value <= 700) {
-            (sprite as am5.Graphics).set("fill", am5.color("#E91E63"));
-          } else if (value <= 800) {
-            (sprite as am5.Graphics).set("fill", am5.color("#F44336"));
+          if (value <= 0) {
+            (sprite as am5.Graphics).set("fill", am5.color("#C41A0A"));
+          } else if (value <= 10) {
+            (sprite as am5.Graphics).set("fill", am5.color("#F4440B"));
+          } else if (value <= 20) {
+            (sprite as am5.Graphics).set("fill", am5.color("#F47A0B"));
+          } else if (value <= 30) {
+            (sprite as am5.Graphics).set("fill", am5.color("#F4B00B"));
+          } else if (value <= 40) {
+            (sprite as am5.Graphics).set("fill", am5.color("#F4E60B"));
+          } else if (value <= 50) {
+            (sprite as am5.Graphics).set("fill", am5.color("#D2EE3C"));
+          } else if (value <= 60) {
+            (sprite as am5.Graphics).set("fill", am5.color("#AFF474"));
+          } else if (value <= 70) {
+            (sprite as am5.Graphics).set("fill", am5.color("#A3D4FF"));
+          } else if (value <= 80) {
+            (sprite as am5.Graphics).set("fill", am5.color("#6DBCFF"));
+          } else if (value <= 90) {
+            (sprite as am5.Graphics).set("fill", am5.color("#1392FF"));
           } else {
-            (sprite as am5.Graphics).set("fill", am5.color("#E03444"));
+            (sprite as am5.Graphics).set("fill", am5.color("#00528F"));
           }
         }
       }]);
-
-      this.humiditySeries.data.setAll([
-        { id: "ID-AC", value: 417 },
-        { id: "ID-BA", value: 156 },
-        { id: "ID-BB", value: 141 },
-        { id: "ID-BE", value: 343 },
-        { id: "ID-BT", value: 225 },
-        { id: "ID-GO", value: 364 },
-        { id: "ID-JA", value: 910 },
-        { id: "ID-JB", value: 588 },
-        { id: "ID-JI", value: 721 },
-        { id: "ID-JK", value: 399 },
-        { id: "ID-JT", value: 522 },
-        { id: "ID-KB", value: 843 },
-        { id: "ID-KI", value: 294 },
-        { id: "ID-KR", value: 515 },
-        { id: "ID-KS", value: 238 },
-        { id: "ID-KT", value: 291 },
-        { id: "ID-KU", value: 136 },
-        { id: "ID-LA", value: 211 },
-        { id: "ID-MA", value: 525 },
-        { id: "ID-MU", value: 421 },
-        { id: "ID-NB", value: 358 },
-        { id: "ID-NT", value: 427 },
-        { id: "ID-PA", value: 294 },
-        { id: "ID-PB", value: 799 },
-        { id: "ID-RI", value: 98 },
-        { id: "ID-SA", value: 801 },
-        { id: "ID-SB", value: 311 },
-        { id: "ID-SG", value: 194 },
-        { id: "ID-SN", value: 436 },
-        { id: "ID-SR", value: 757 },
-        { id: "ID-SS", value: 28 },
-        { id: "ID-ST", value: 501 },
-        { id: "ID-SU", value: 442 },
-        { id: "ID-YO", value: 357 }
-      ])
 
       // Create custom legend
       let legend = this.chart.children.push(am5.Container.new(root, {
@@ -297,17 +267,6 @@ export class MapChartService {
           strokeWidth: 1,
       });
 
-      // Add hover effect using the helper function
-      /* istanbul ignore next */
-      this.basePolygonSeries.mapPolygons.template.events.on("pointerover", (ev) => {
-        this.handlePolygonEvent(ev, "#FF0000");
-      });
-
-      /* istanbul ignore next */
-      this.basePolygonSeries.mapPolygons.template.events.on("pointerout", (ev) => {
-        this.handlePolygonEvent(ev, "#E0E0E0");
-      });
-
       /* istanbul ignore next */
       this.chart.set("background", am5.Rectangle.new(this.root, {
           fill: am5.color("#E0E0E0"), 
@@ -321,20 +280,6 @@ export class MapChartService {
     } catch (error) {
       console.error("Error setting up polygon series:", error);
       if (this.onError) this.onError("Error setting up map polygons.");
-    }
-  }
-
-  /* istanbul ignore next */
-  private handlePolygonEvent(ev: any, fillColor: string): void {
-    const polygon = ev.target;
-    if (polygon && this.highlightSeries?.mapPolygons) {
-      const index = this.basePolygonSeries?.mapPolygons.indexOf(polygon);
-      if (index !== undefined) {
-        const highlightPolygon = this.highlightSeries.mapPolygons.getIndex(index);
-        if (highlightPolygon) {
-          highlightPolygon.set("fill", am5.color(fillColor));
-        }
-      }
     }
   }
 
@@ -363,6 +308,7 @@ export class MapChartService {
     if (!this.pointSeries || !this.root) return;
     try {
       const root = this.root;
+      const self = this; // Store reference to this
       /* istanbul ignore next */
       this.pointSeries.set("clusteredBullet", (root: am5.Root) => {
         const container = am5.Container.new(root, {
@@ -394,7 +340,20 @@ export class MapChartService {
 
         container.events.on("click", (e) => {
           if (e.target.dataItem) {
-            this.pointSeries?.zoomToCluster(e.target.dataItem as am5.DataItem<any>);
+            console.log("CLICKED");
+            try {
+              console.log("Attempting to zoom to cluster with dataItem:", e.target.dataItem);
+              // Check if zoomToCluster method exists
+              if (self.pointSeries && typeof self.pointSeries.zoomToCluster === 'function') {
+                // Pass true as second parameter to center the cluster
+                self.pointSeries.zoomToCluster(e.target.dataItem as am5.DataItem<any>, true);
+                console.log("Successfully called zoomToCluster with center parameter");
+              } else {
+                console.error("zoomToCluster method is not available on pointSeries", self.pointSeries);
+              }
+            } catch (error) {
+              console.error("Error in zoomToCluster:", error);
+            }
           }
         });
 
@@ -473,6 +432,22 @@ export class MapChartService {
     // Set the tooltip for the series
     this.pointSeries.set("tooltip", tooltip);
   }
+
+  populateProvinceHumidityData(provinceHumidityData: ProvinceData[]): void {
+    if (!this.humiditySeries) return;
+    this.provinceHumidityData = provinceHumidityData;
+    this.humiditySeries.data.clear();
+    console.log(provinceHumidityData);
+
+    provinceHumidityData.forEach(data => {
+      this.humiditySeries!.data.push({
+        id: data.id,
+        value: data.value
+      });
+    });
+    
+    console.log(this.humiditySeries.data);   
+  }
   
   populateLocations(locations: MapLocation[]): void {
     if (!this.pointSeries) return;
@@ -487,8 +462,8 @@ export class MapChartService {
         geometry: { 
           type: "Point", 
           coordinates: [
-            location.location__longitude, 
-            location.location__latitude,
+            parseFloat(location.location__longitude), 
+            parseFloat(location.location__latitude),
           ] 
         },
         city: location.city,

--- a/services/mapChartService.ts
+++ b/services/mapChartService.ts
@@ -14,7 +14,7 @@ export class MapChartService {
   private basePolygonSeries: am5map.MapPolygonSeries | null = null;
   private highlightSeries: am5map.MapPolygonSeries | null = null;
   private humiditySeries: am5map.MapPolygonSeries | null = null;
-  private humidityHeatLegend: am5.HeatLegend | null = null;
+  private humidityHeatLegend: am5.Container | null = null;
   private readonly onError: ((message: string) => void) | null = null;
   private locations: MapLocation[] | null = null;
   private _countSelectedPoints: number = 0;
@@ -217,30 +217,65 @@ export class MapChartService {
         { id: "ID-YO", value: 357 }
       ])
 
-      this.humidityHeatLegend = this.chart.children.push(am5.HeatLegend.new(root, {
-        orientation: "horizontal",
-        startColor: am5.color("#FFFFFF"),
-        endColor: am5.color("#E03444"),
-        startText: "Lowest",
-        endText: "Highest",
-        stepCount: 9,
+      // Create custom legend
+      let legend = this.chart.children.push(am5.Container.new(root, {
         maxWidth: 1000,
+        height: 100,
+        layout: root.verticalLayout,
         paddingTop: 800,
-        paddingLeft: 600,
-        paddingRight: -200
+        paddingLeft: 0,
+        paddingRight: 0
       }));
-      
-      /* istanbul ignore next */
-      this.humidityHeatLegend.startLabel.setAll({
-        fontSize: 12,
-        fill: this.humidityHeatLegend.get("startColor")
+
+      let gradient = am5.LinearGradient.new(root, {
+        stops: [
+          { color: am5.color("#FFFFFF"), offset: 0 },
+          { color: am5.color("#FFFFFF"), offset: 0.1 },
+          { color: am5.color("#A5D6A7"), offset: 0.1 },
+          { color: am5.color("#A5D6A7"), offset: 0.2 },
+          { color: am5.color("#4CAF50"), offset: 0.2 },
+          { color: am5.color("#4CAF50"), offset: 0.3 },
+          { color: am5.color("#2196F3"), offset: 0.3 },
+          { color: am5.color("#2196F3"), offset: 0.4 },
+          { color: am5.color("#3F51B5"), offset: 0.4 },
+          { color: am5.color("#3F51B5"), offset: 0.5 },
+          { color: am5.color("#9C27B0"), offset: 0.5 },
+          { color: am5.color("#9C27B0"), offset: 0.6 },
+          { color: am5.color("#E91E63"), offset: 0.6 },
+          { color: am5.color("#E91E63"), offset: 0.7 },
+          { color: am5.color("#F44336"), offset: 0.7 },
+          { color: am5.color("#F44336"), offset: 0.8 },
+          { color: am5.color("#E03444"), offset: 0.8 },
+          { color: am5.color("#E03444"), offset: 1 }
+        ],
+        rotation: 0
       });
-      
-      /* istanbul ignore next */
-      this.humidityHeatLegend.endLabel.setAll({
+
+      let labels = legend.children.push(am5.Container.new(root, {
+        width: am5.p100
+      }));
+
+      let fromLabel = labels.children.push(am5.Label.new(root, {
+        text: "Lowest",
+        fontSize: 12
+      }));
+
+      let toLabel = labels.children.push(am5.Label.new(root, {
+        text: "Highest",
         fontSize: 12,
-        fill: this.humidityHeatLegend.get("endColor")
-      });
+        x: am5.p100,
+        centerX: am5.p100
+      }));
+
+      let bar = legend.children.push(am5.Rectangle.new(root, {
+        width: am5.p50,
+        height: 40,
+        fillGradient: gradient,
+        fillOpacity: 1
+      }));
+
+      // Store the legend for later use
+      this.humidityHeatLegend = legend;
       
       /* istanbul ignore next */
       // Initially hide the humidity layer

--- a/types/index.ts
+++ b/types/index.ts
@@ -69,3 +69,8 @@ export interface StatisticsData {
     all_healthcare: Array<{ portal: string; news_count: number; disease_count: number }>;
   };
 }
+
+export interface ProvinceData {
+  id: string;
+  value: string | number;
+}


### PR DESCRIPTION
# 🧾 Overview
This Merge Request introduces layer control functionality to the `mapChartService`, allowing users to toggle the visibility of Rainfall map layer.

---

# 🔧 Changes

## 🗺️ Map Layer Control
- Added functions to manage the visibility of map layers in the `mapChartService`.

## 🌧️ Rainfall Map Layer
- Implemented a new map layer to visualize **Rainfall per province**.
- Rainfall category as of now is still temporary.

---

# ✅ How to Test

## 1. Install Dependencies
```bash
npm install
```
## 2. Run Test
```bash
npm test
```
Coverage and test summary will be displayed on the terminal.

# Future Work
## Define Rainfall Category
- Current Rainfall category is still temporary. Will define one in the future.
## Dummy Data Integration
- The current Rainfall map uses static data.
- Upcoming updates will replace this with integrated dummy data.